### PR TITLE
Update Readme.md closing last code example

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Better create "Unknown" option in your enum. That way you can write nicer code i
     function getPaymentMethod() {
        return PaymentMethod::fromId($id);
     }
-
+```
 
 ## Ending
 


### PR DESCRIPTION
Last code example was not properly closed thus making `##Ending` heading be show as code.